### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-message.yml
+++ b/.github/workflows/release-message.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   github-releases-to-discord:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PixelPizza/OurTube/security/code-scanning/6](https://github.com/PixelPizza/OurTube/security/code-scanning/6)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the required permissions. Based on the workflow's functionality, it only needs read access to the repository contents. Therefore, the `permissions` block should specify `contents: read`. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
