### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,5 +1,8 @@
 name: Continuous Integration
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/PixelPizza/OurTube/security/code-scanning/7](https://github.com/PixelPizza/OurTube/security/code-scanning/7)

To fix the problem, we should add a top-level `permissions` block to the workflow YAML file (`.github/workflows/continuous-integration.yml`). This block, placed at the root level (alongside `name` and `on`), sets the default permissions for all jobs in the workflow. Given that none of the jobs (`lint`, `build`, `test`) require write privileges (they just check out code, build, and run tests), the safest approach is to specify `contents: read`, which is the minimum necessary for steps like `actions/checkout`. No additional permissions are necessary unless jobs are subsequently added which interact with issues or PRs in a write capacity. Insert the following block at the root of the YAML, after the `name:` and before or after the `on:` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
